### PR TITLE
docs: fix wrong github link

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -622,7 +622,7 @@ export default defineConfigWithTheme<ThemeConfig>({
       {
         link: 'http://ko.vuejs.org',
         text: '한국어',
-        repo: 'https://github.com/vuejs-translations/vuejs-kr'
+        repo: 'https://github.com/vuejs-translations/docs-ko'
       },
       {
         link: '/translations/',
@@ -652,7 +652,7 @@ export default defineConfigWithTheme<ThemeConfig>({
     ],
 
     editLink: {
-      repo: 'vuejs/docs',
+      repo: '/vuejs-translations/docs-ko',
       text: 'GitHub에서 이 페이지 편집'
     },
 


### PR DESCRIPTION
## Description of Problem

- The official Korean Github link is wrong
- Edit documentation link points to official repositories, not the language-specific repositories.

## Proposed Solution

- The official Korean Github link fix to 'https://github.com/vuejs-translations/docs-ko'
- Changed the edit document link from 'vuejs/docs' to 'vuejs-translations/docs-ko'

## Additional Information
