### PR TITLE
fix: enable Vercel's cleanUrls options to avoid redirection issue

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,7 @@
       "destination": "https://v2.ko.vuejs.org/v2/:path*"
     }
   ],
+  "cleanUrls": true,
   "git": {
     "deploymentEnabled": {
       "gh-pages": false,


### PR DESCRIPTION
## Description of Problem
When no extension is used, page is broken with redirection: https://ko.vuejs.org/guide/introduction

## Proposed Solution

Suggested by Evan You in private: vuejs.org uses Netlify with `cleanUrls` enabled.
Enabling it is solving the issue.
