### PR TITLE
fix: grid 컬럼 키 불일치로 값 미표시 문제 수정

### DIFF
--- a/src/examples/src/grid/App/composition.js
+++ b/src/examples/src/grid/App/composition.js
@@ -7,7 +7,7 @@ export default {
   },
   setup() {
     const searchQuery = ref('')
-    const gridColumns = ['이름', '전투력']
+    const gridColumns = ['name', 'power']
     const gridData = [
       { name: '척 노리스', power: Infinity },
       { name: '브루스 리', power: 9000 },

--- a/src/examples/src/grid/App/options.js
+++ b/src/examples/src/grid/App/options.js
@@ -6,7 +6,7 @@ export default {
   },
   data: () => ({
     searchQuery: '',
-    gridColumns: ['이름', '전투력'],
+    gridColumns: ['name', 'power'],
     gridData: [
       { name: '척 노리스', power: Infinity },
       { name: '브루스 리', power: 9000 },


### PR DESCRIPTION
- 문제: Grid 예제에서 columns가 ['이름','전투력']로 번역되어 data의 { name, power }와 불일치 → 값 미표시 및 정렬 오동작
- 해결: columns를 ['name','power']로 수정 (키는 영문 유지)
- 페이지: https://ko.vuejs.org/examples/#grid
- 변경 파일:
  - src/examples/src/grid/App/composition.js
  - src/examples/src/grid/App/options.js

(전)
<img width="778" height="716" alt="스크린샷 2025-08-11 오후 8 46 51" src="https://github.com/user-attachments/assets/32905c9f-e7be-4dce-bc0a-5489d8bba787" />

(후)
<img width="653" height="505" alt="스크린샷 2025-08-11 오후 8 47 00" src="https://github.com/user-attachments/assets/8f04f88c-14db-4f17-9520-7a773bc4183c" />
