### PR TITLE
docs: fix LRU cache wiki link in KeepAlive max prop description

### DIFF
--- a/src/guide/built-ins/keep-alive.md
+++ b/src/guide/built-ins/keep-alive.md
@@ -79,7 +79,7 @@ import SwitchComponent from './keep-alive-demos/SwitchComponent.vue'
 
 ## 최대 캐시 인스턴스 수 {#max-cached-instances}
 
-`max` prop을 통해 캐시할 수 있는 컴포넌트 인스턴스의 최대 개수를 제한할 수 있습니다. `max`가 지정되면, `<KeepAlive>`는 [LRU 캐시](<https://ko.wikipedia.org/wiki/%EC%B9%B4%EC%8B%9C_%EA%B5%90%EC%B2%B4_%EC%A0%95%EC%B1%85#%EA%B7%80%EC%9E%91%EC%9D%B4_%EA%B0%80%EC%9E%A5_%EC%98%A4%EB%9E%98%EB%90%9C_%EA%B2%BD%EC%9A%B0_(LRU)>)처럼 동작합니다. 캐시된 인스턴스의 수가 지정한 최대 개수를 초과하려고 하면, 가장 오랫동안 접근하지 않은 캐시 인스턴스가 파괴되어 새로운 인스턴스를 위한 공간을 만듭니다.
+`max` prop을 통해 캐시할 수 있는 컴포넌트 인스턴스의 최대 개수를 제한할 수 있습니다. `max`가 지정되면, `<KeepAlive>`는 [LRU 캐시](<https://ko.wikipedia.org/wiki/%EC%BA%90%EC%8B%9C_%EA%B5%90%EC%B2%B4_%EC%A0%95%EC%B1%85#%EC%B5%9C%EA%B7%BC_%EC%B5%9C%EC%86%8C_%EC%82%AC%EC%9A%A9_(LRU)>)처럼 동작합니다. 캐시된 인스턴스의 수가 지정한 최대 개수를 초과하려고 하면, 가장 오랫동안 접근하지 않은 캐시 인스턴스가 파괴되어 새로운 인스턴스를 위한 공간을 만듭니다.
 
 ```vue-html
 <KeepAlive :max="10">


### PR DESCRIPTION
## Description of Problem

`KeepAlive` 컴포넌트의 `max` prop 설명에서 사용된 **LRU 캐시 위키 링크의 한국어 앵커가 잘못된 경로로 연결**되어 있었습니다.  
기존 링크는 LRU 설명이 있는 올바른 섹션으로 이동하지 않아 문서를 참고할 때 혼동을 줄 수 있습니다.

- 문제가 발생한 위치:  
`src/guide/built-ins/keep-alive.md`
- 문제가 확인된 페이지:
https://ko.vuejs.org/guide/built-ins/keep-alive#max-cached-instances

## Proposed Solution

LRU 캐시 설명이 포함된 **URL 인코딩된 한국어 위키 링크의 섹션 앵커를 올바르게 수정**했습니다.

* 기존: `카시_교체_정책#귀작이_가장_오래된_경우_(LRU)`
* 수정: `캐시_교체_정책#최근_최소_사용_(LRU)`

<img width="185" height="78" alt="image" src="https://github.com/user-attachments/assets/66cc0777-45aa-44b6-8ac6-5a04d2616f76" />
<br /><br />

이를 통해 LRU 캐시 설명 섹션으로 정확히 이동하도록 수정했습니다.

## Additional Information

이번 변경은 **문서의 한국어 위키 링크 앵커만 수정한 것으로 기능적인 영향은 없습니다.**