### PR TITLE
Update Solid Signals link to correct documentation

### DIFF
--- a/src/guide/extras/reactivity-in-depth.md
+++ b/src/guide/extras/reactivity-in-depth.md
@@ -402,7 +402,7 @@ export function useMachine(options) {
 
 다른 여러 프레임워크가 Vue의 컴포지션 API의 ref와 유사한 반응성 프리미티브를 "시그널"이라는 용어로 도입했습니다:
 
-- [Solid Signals](https://www.solidjs.com/docs/latest/api#createsignal)
+- [Solid Signals](https://docs.solidjs.com/concepts/signals)
 - [Angular Signals](https://angular.dev/guide/signals)
 - [Preact Signals](https://preactjs.com/guide/v10/signals/)
 - [Qwik Signals](https://qwik.builder.io/docs/components/state/#usesignal)


### PR DESCRIPTION
## Description of Problem
The link to Solid's Signals documentation in `src/guide/extras/reactivity-in-depth.md` was pointing to outdated documentation.

## Proposed Solution
Updated the Solid Signals link to point to the correct documentation, matching the change made in the English source (vuejs/docs#3308).

## Additional Information
Closes #556